### PR TITLE
Support asynchronous followRedirect filter (callback or promise)

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,7 +777,10 @@ The first argument can be either a `url` or an `options` object. The only requir
 
 ---
 
-- `followRedirect` - follow HTTP 3xx responses as redirects (default: `true`). This property can also be implemented as function which gets `response` object as a single argument and should return `true` if redirects should continue or `false` otherwise.
+- `followRedirect` - follow HTTP 3xx responses as redirects (default: `true`). This property can also be implemented as function which gets `response` object as the first argument.
+  - *(synchronous usage)* It should return `true` if redirects should continue or `false` otherwise. If it returns a url string, the destination of the redirect will be overridden.
+  - *(async callback usage)* If the function has two arguments, it will be treated as an asynchronous function and will be passed a callback as the second argument. Invoke the callback with an error (`null` if no error) and the boolean/url result as the second.
+  - *(async promise usage)* Return a promise that resolves to the boolean/url result.
 - `followAllRedirects` - follow non-GET HTTP 3xx responses as redirects (default: `false`)
 - `followOriginalHttpMethod` - by default we redirect to HTTP method GET. you can enable this property to redirect to the original HTTP method (default: `false`)
 - `maxRedirects` - the maximum number of redirects to follow (default: `10`)

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -76,79 +76,100 @@ Redirect.prototype.redirectTo = function (response) {
   return redirectTo
 }
 
-Redirect.prototype.onResponse = function (response) {
+Redirect.prototype.onResponse = function (response, callback) {
   var self = this
   var request = self.request
 
   var redirectTo = self.redirectTo(response)
-  if (!redirectTo || !self.allowRedirect.call(request, response)) {
-    return false
-  }
+  if (!redirectTo) return callback(null, false)
 
-  request.debug('redirect to', redirectTo)
+  function processRedirect (shouldRedirect) {
+    if (!shouldRedirect) return callback(null, false)
+    if (typeof shouldRedirect === 'string') {
+      // overridden redirect url
+      request.debug('redirect overridden', redirectTo)
+      redirectTo = shouldRedirect
+    }
 
-  // ignore any potential response body.  it cannot possibly be useful
-  // to us at this point.
-  // response.resume should be defined, but check anyway before calling. Workaround for browserify.
-  if (response.resume) {
-    response.resume()
-  }
+    request.debug('redirect to', redirectTo)
 
-  if (self.redirectsFollowed >= self.maxRedirects) {
-    request.emit('error', new Error('Exceeded maxRedirects. Probably stuck in a redirect loop ' + request.uri.href))
-    return false
-  }
-  self.redirectsFollowed += 1
+    // ignore any potential response body.  it cannot possibly be useful
+    // to us at this point.
+    // response.resume should be defined, but check anyway before calling. Workaround for browserify.
+    if (response.resume) {
+      response.resume()
+    }
 
-  if (!isUrl.test(redirectTo)) {
-    redirectTo = url.resolve(request.uri.href, redirectTo)
-  }
+    if (self.redirectsFollowed >= self.maxRedirects) {
+      return callback(new Error('Exceeded maxRedirects. Probably stuck in a redirect loop ' + request.uri.href))
+    }
+    self.redirectsFollowed += 1
 
-  var uriPrev = request.uri
-  request.uri = url.parse(redirectTo)
+    if (!isUrl.test(redirectTo)) {
+      redirectTo = url.resolve(request.uri.href, redirectTo)
+    }
 
-  // handle the case where we change protocol from https to http or vice versa
-  if (request.uri.protocol !== uriPrev.protocol) {
-    delete request.agent
-  }
+    var uriPrev = request.uri
+    request.uri = url.parse(redirectTo)
 
-  self.redirects.push({ statusCode: response.statusCode, redirectUri: redirectTo })
+    // handle the case where we change protocol from https to http or vice versa
+    if (request.uri.protocol !== uriPrev.protocol) {
+      delete request.agent
+    }
 
-  if (self.followAllRedirects && request.method !== 'HEAD' &&
-    response.statusCode !== 401 && response.statusCode !== 307) {
-    request.method = self.followOriginalHttpMethod ? request.method : 'GET'
-  }
-  // request.method = 'GET' // Force all redirects to use GET || commented out fixes #215
-  delete request.src
-  delete request.req
-  delete request._started
-  if (response.statusCode !== 401 && response.statusCode !== 307) {
-    // Remove parameters from the previous response, unless this is the second request
-    // for a server that requires digest authentication.
-    delete request.body
-    delete request._form
-    if (request.headers) {
-      request.removeHeader('host')
-      request.removeHeader('content-type')
-      request.removeHeader('content-length')
-      if (request.uri.hostname !== request.originalHost.split(':')[0]) {
-        // Remove authorization if changing hostnames (but not if just
-        // changing ports or protocols).  This matches the behavior of curl:
-        // https://github.com/bagder/curl/blob/6beb0eee/lib/http.c#L710
-        request.removeHeader('authorization')
+    self.redirects.push({ statusCode: response.statusCode, redirectUri: redirectTo })
+
+    if (self.followAllRedirects && request.method !== 'HEAD' &&
+      response.statusCode !== 401 && response.statusCode !== 307) {
+      request.method = self.followOriginalHttpMethod ? request.method : 'GET'
+    }
+    // request.method = 'GET' // Force all redirects to use GET || commented out fixes #215
+    delete request.src
+    delete request.req
+    delete request._started
+    if (response.statusCode !== 401 && response.statusCode !== 307) {
+      // Remove parameters from the previous response, unless this is the second request
+      // for a server that requires digest authentication.
+      delete request.body
+      delete request._form
+      if (request.headers) {
+        request.removeHeader('host')
+        request.removeHeader('content-type')
+        request.removeHeader('content-length')
+        if (request.uri.hostname !== request.originalHost.split(':')[0]) {
+          // Remove authorization if changing hostnames (but not if just
+          // changing ports or protocols).  This matches the behavior of curl:
+          // https://github.com/bagder/curl/blob/6beb0eee/lib/http.c#L710
+          request.removeHeader('authorization')
+        }
       }
     }
+
+    if (!self.removeRefererHeader) {
+      request.setHeader('referer', uriPrev.href)
+    }
+
+    request.emit('redirect')
+    request.init()
+    callback(null, true)
   }
 
-  if (!self.removeRefererHeader) {
-    request.setHeader('referer', uriPrev.href)
+  // test allowRedirect arity; if has more than one argument,
+  // assume it's asynchronous via a callback
+  if (self.allowRedirect.length > 1) {
+    return self.allowRedirect.call(request, response, function (err, result) {
+      if (err) return callback(err)
+      processRedirect(result)
+    })
   }
 
-  request.emit('redirect')
+  var allowsRedirect = self.allowRedirect.call(request, response)
+  if (allowsRedirect && allowsRedirect.then) {
+    return allowsRedirect.then(processRedirect, callback)
+  }
 
-  request.init()
-
-  return true
+  // treat as a regular boolean
+  processRedirect(allowsRedirect)
 }
 
 exports.Redirect = Redirect

--- a/request.js
+++ b/request.js
@@ -987,9 +987,10 @@ Request.prototype.onRequestResponse = function (response) {
     }
   }
 
-  if (self._redirect.onResponse(response)) {
-    return // Ignore the rest of the response
-  } else {
+  self._redirect.onResponse(response, function (err, followingRedirect) {
+    if (!err && followingRedirect) return // Ignore the rest of the response
+    if (err) self.emit('error', err)
+
     // Be a good stream and emit end when the response is finished.
     // Hack to emit end on close because of a core bug that never fires end
     response.on('close', function () {
@@ -1100,8 +1101,8 @@ Request.prototype.onRequestResponse = function (response) {
         self.emit('complete', response)
       })
     }
-  }
-  debug('finish init function', self.uri.href)
+    debug('finish init function', self.uri.href)
+  })
 }
 
 Request.prototype.readResponseBody = function (response) {


### PR DESCRIPTION
Needed for hostname to ip resolution, which can be used to disallow
redirection to internal network addresses.

This PR also allows the followRedirect result to be a string, which
effectively overrides the redirect location. This can be used translate
the target hostname to a ip (locking it)

https://www.gnu.gl/blog/Posts/multiple-vulnerabilities-in-pocket/
https://news.ycombinator.com/item?id=12670316

## PR Checklist:
- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
