### PR TITLE
Support bufferEncoding option in the library api

### DIFF
--- a/request.js
+++ b/request.js
@@ -1126,8 +1126,8 @@ Request.prototype.readResponseBody = function (response) {
     if (bufferLength) {
       debug('has body', self.uri.href, bufferLength)
       response.body = Buffer.concat(buffers, bufferLength)
-      if (self.encodeBodyToBase64) {
-        response.body = response.body.toString('base64')
+      if (self.bufferEncoding !== null && Buffer.isEncoding(self.bufferEncoding)) {
+        response.body = response.body.toString(self.bufferEncoding)
       } else if (self.encoding !== null) {
         response.body = response.body.toString(self.encoding)
       }

--- a/request.js
+++ b/request.js
@@ -1126,7 +1126,9 @@ Request.prototype.readResponseBody = function (response) {
     if (bufferLength) {
       debug('has body', self.uri.href, bufferLength)
       response.body = Buffer.concat(buffers, bufferLength)
-      if (self.encoding !== null) {
+      if (self.encodeBodyToBase64) {
+        response.body = response.body.toString('base64')
+      } else if (self.encoding !== null) {
         response.body = response.body.toString(self.encoding)
       }
       // `buffer` is defined in the parent scope and used in a closure it exists for the life of the Request.


### PR DESCRIPTION
## PR Description

This PR is a _must_ with [this PR](https://github.com/cypress-io/cypress/pull/7380) in the main cypress repo to solve [this issue](https://github.com/cypress-io/cypress/issues/3576) of getting a broken PDF file.

As a first step to support the `bufferEncoding` option in the `request` library is suggested. It was proven to be working locally.

The possible values for the `bufferEncoding` would be all the values listed in [Node documentation](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings):
- `utf8`
- `utf16le`
- `latin1`
- `base64`
- `hex`
- `ascii`
- `binary` alias for latin1
- `ucs2` alias for utf16le

Further/detailed explanation can be found in the other PR of the main cypress repo: https://github.com/cypress-io/cypress/pull/7380

## PR Checklist (TODO):
- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->