### PR TITLE
feat: Add allowInsecureRedirect option

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ The first argument can be either a `url` or an `options` object. The only requir
 - `followOriginalHttpMethod` - by default we redirect to HTTP method GET. you can enable this property to redirect to the original HTTP method (default: `false`)
 - `maxRedirects` - the maximum number of redirects to follow (default: `10`)
 - `removeRefererHeader` - removes the referer header when a redirect happens (default: `false`). **Note:** if true, referer header set in the initial request is preserved during redirect chain.
+- `allowInsecureRedirect` - allows cross-protocol redirects (HTTP to HTTPS and vice versa). **Warning:** may lead to bypassing anti SSRF filters
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ The first argument can be either a `url` or an `options` object. The only requir
 - `followOriginalHttpMethod` - by default we redirect to HTTP method GET. you can enable this property to redirect to the original HTTP method (default: `false`)
 - `maxRedirects` - the maximum number of redirects to follow (default: `10`)
 - `removeRefererHeader` - removes the referer header when a redirect happens (default: `false`). **Note:** if true, referer header set in the initial request is preserved during redirect chain.
-- `allowInsecureRedirect` - allows cross-protocol redirects (HTTP to HTTPS and vice versa). **Warning:** may lead to bypassing anti SSRF filters
+- `allowInsecureRedirect` - allows cross-protocol redirects (HTTP to HTTPS and vice versa). **Warning:** may lead to bypassing anti SSRF filters (default: `false`)
 
 ---
 

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -14,6 +14,7 @@ function Redirect (request) {
   this.redirects = []
   this.redirectsFollowed = 0
   this.removeRefererHeader = false
+  this.allowInsecureRedirect = false
 }
 
 Redirect.prototype.onRequest = function (options) {
@@ -39,6 +40,9 @@ Redirect.prototype.onRequest = function (options) {
   }
   if (options.followOriginalHttpMethod !== undefined) {
     self.followOriginalHttpMethod = options.followOriginalHttpMethod
+  }
+  if (options.allowInsecureRedirect !== undefined) {
+    self.allowInsecureRedirect = options.allowInsecureRedirect
   }
 }
 
@@ -113,7 +117,7 @@ Redirect.prototype.onResponse = function (response, callback) {
     request.uri = url.parse(redirectTo)
 
     // handle the case where we change protocol from https to http or vice versa
-    if (request.uri.protocol !== uriPrev.protocol) {
+    if (request.uri.protocol !== uriPrev.protocol && self.allowInsecureRedirect) {
       delete request.agent
     }
 

--- a/tests/test-httpModule.js
+++ b/tests/test-httpModule.js
@@ -70,7 +70,7 @@ function runTests (name, httpModules) {
   tape(name, function (t) {
     var toHttps = 'http://localhost:' + plainServer.port + '/to_https'
     var toPlain = 'https://localhost:' + httpsServer.port + '/to_plain'
-    var options = { httpModules: httpModules, strictSSL: false }
+    var options = { httpModules: httpModules, strictSSL: false, allowInsecureRedirect: true }
     var modulesTest = httpModules || {}
 
     clearFauxRequests()

--- a/tests/test-redirect-auth.js
+++ b/tests/test-redirect-auth.js
@@ -18,6 +18,7 @@ request = request.defaults({
     user: 'test',
     pass: 'testing'
   },
+  allowInsecureRedirect: true,
   rejectUnauthorized: false
 })
 

--- a/tests/test-redirect-complex.js
+++ b/tests/test-redirect-complex.js
@@ -67,6 +67,7 @@ tape('lots of redirects', function (t) {
     request({
       url: (i % 2 ? s.url : ss.url) + '/a',
       headers: { 'x-test-key': key },
+      allowInsecureRedirect: true,
       rejectUnauthorized: false
     }, function (err, res, body) {
       t.equal(err, null)

--- a/tests/test-redirect.js
+++ b/tests/test-redirect.js
@@ -445,11 +445,24 @@ tape('http to https redirect', function (t) {
   hits = {}
   request.get({
     uri: require('url').parse(s.url + '/ssl'),
-    rejectUnauthorized: false
+    rejectUnauthorized: false,
+    allowInsecureRedirect: true
   }, function (err, res, body) {
     t.equal(err, null)
     t.equal(res.statusCode, 200)
     t.equal(body, 'SSL', 'Got SSL redirect')
+    t.end()
+  })
+})
+
+tape('http to https redirect should fail without the explicit "allowInsecureRedirect" option', function (t) {
+  hits = {}
+  request.get({
+    uri: require('url').parse(s.url + '/ssl'),
+    rejectUnauthorized: false
+  }, function (err, res, body) {
+    t.notEqual(err, null)
+    t.equal(err.code, 'ERR_INVALID_PROTOCOL', 'Failed to cross-protocol redirect')
     t.end()
   })
 })

--- a/tests/test-tunnel.js
+++ b/tests/test-tunnel.js
@@ -356,6 +356,7 @@ function addTests () {
     'https->http over http, tunnel=true',
     {
       url: ss.url + '/redirect/http',
+      allowInsecureRedirect: true,
       proxy: s.url,
       tunnel: true
     },
@@ -372,6 +373,7 @@ function addTests () {
     'https->http over http, tunnel=false',
     {
       url: ss.url + '/redirect/http',
+      allowInsecureRedirect: true,
       proxy: s.url,
       tunnel: false
     },
@@ -388,6 +390,7 @@ function addTests () {
     'https->http over http, tunnel=default',
     {
       url: ss.url + '/redirect/http',
+      allowInsecureRedirect: true,
       proxy: s.url
     },
     [


### PR DESCRIPTION
  ## PR Checklist:
  - [x] I have run `npm test` locally and all tests are passing.
  - [x] I have added/updated tests for any new behavior.
  - [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #27
         <!-- If you'd like to suggest a significant change to request,
                 please create an issue to discuss those changes and gather
                 feedback BEFORE submitting your PR. -->
  
  
  ## PR Description
  - Ported from https://github.com/request/request/pull/3444
    - Existing behavior allows malicious redirects between protocols
    - Set default behavior to disable protocol downgrade in redirects (breaking)
    - Add new option `allowInsecureRedirect` where `true` reverts to old behavior
  - Update cypress tests to use `allowInsecureRedirect: true` for applicable cases

A non-breaking (and therefore not-safe-by-default) alternative in #30.