### PR TITLE
fix(deps): lock qs to 6.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "json-stringify-safe": "~5.0.1",
     "mime-types": "~2.1.19",
     "performance-now": "^2.1.0",
-    "qs": "~6.10.3",
+    "qs": "6.10.4",
     "safe-buffer": "^5.1.2",
     "tough-cookie": "^4.1.3",
     "tunnel-agent": "^0.6.0",


### PR DESCRIPTION
- closes #42

## PR Checklist:
- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: https://github.com/cypress-io/request/issues/42

## PR Description

- This PR changes the dependency [qs](https://www.npmjs.com/package/qs) from using a semver definition `~6.10.3` to using a fixed version `6.10.4` according to one option in the recommendation from `qs@6.10.5`:

>$ npm view qs@6.10.5 deprecated
when using stringify with arrayFormat comma, `[]` is appended on single-item arrays. Upgrade to v6.11.0 or downgrade to v6.10.4 to fix.

- This PR supersedes https://github.com/cypress-io/request/pull/43 as a low risk alternative to resolving #42, since it simply locks the minor version of `qs` to `6.10.4`.

## Notes

The PR does not change the version of `qs` chosen when installing `@cypress/request` with npm or pnpm.

The PR forces the choice of `qs` version made by Yarn so that it corresponds to the version choice made by npm and pnpm, which already resolve `~6.10.3` to the selection `6.10.4`. This avoids that Yarn chooses the deprecated `6.10.5` version.

[npm-pick-manifest](https://www.npmjs.com/package/npm-pick-manifest) mentions the algorithm whereby npm "Prefers non-deprecated versions to deprecated versions".
