### PR TITLE
chore(deps): update GitHub action versions for node20 compatibility

### DIFF
--- a/.github/workflows/yarn.yaml
+++ b/.github/workflows/yarn.yaml
@@ -5,8 +5,8 @@ jobs:
     name: Install and test with yarn
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "18.16"
       - run: yarn install


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description

This PR updates [workflows/yarn.yaml](https://github.com/cypress-io/request/blob/master/.github/workflows/yarn.yaml) to:

- [actions/checkout@v4](https://github.com/actions/checkout)
- [actions/setup-node@v4](https://github.com/actions/setup-node)

for compatibility with `node20`.

GitHub already announced the deprecation of `node16` in their blog  [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) on Sep 22, 2023.

