### PR TITLE
chore(deps): update circleci test to cimg/node:18.20.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/node:17
+      - image: cimg/node:18.20.4
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
## Issue

The CircleCI `test` job is using `circleci/node:17`

https://github.com/cypress-io/request/blob/6acc8138c0e550ebae37d5182e0a2a77e15b7e02/.circleci/config.yml#L3-L5

- CircleCI deprecated Docker images with namespace `circleci` in August 2021 and replaced these with `cimg` Docker images (see [job 179](https://app.circleci.com/pipelines/github/cypress-io/request/149/workflows/a59801e2-e2af-40a5-a939-13a97edc0f55/jobs/179) and [Legacy Convenience Image Deprecation](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034)).

- Node.js `17` reached [end-of-life](https://github.com/nodejs/release#release-schedule) on June 1, 2022.

## Change

Update the CircleCI Docker image used in the `test` job of [.circleci/config.yml](https://github.com/cypress-io/request/blob/6acc8138c0e550ebae37d5182e0a2a77e15b7e02/.circleci/config.yml) to

`cimg/node:18.20.4`

This is the latest Node.js `18.x` image.

- Issue https://github.com/cypress-io/request/issues/68 limits Node.js to `18.x` due to `test` job failure in higher supported Node.js versions.