### PR TITLE
ci: work around yarn install failure on Node.js 18.x

### DIFF
--- a/.github/workflows/yarn.yaml
+++ b/.github/workflows/yarn.yaml
@@ -9,5 +9,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "18.16"
-      - run: yarn install
+
+        # --ignore engines added due to Yarn Classic bug installing under Node.js 18.x
+        # https://github.com/cypress-io/request/issues/89
+      - run: yarn install --ignore-engines
       - run: yarn test


### PR DESCRIPTION
- closes https://github.com/cypress-io/request/issues/89

## Situation

GitHub Actions CI workflow [yarn.yaml](https://github.com/cypress-io/request/blob/master/.github/workflows/yarn.yaml) runs against `node-version: 18.16`, where the command `yarn install` fails:

```text
[3/5] Fetching packages...
error ink@6.0.1: The engine "node" is incompatible with this module. Expected version ">=20". Got "18.16.1"
error Found incompatible module.
```

Yarn should not be attempting to use `ink@6.0.1` as [ink@3.2.0](https://github.com/vadimdemedes/ink/releases/tag/v3.2.0) is defined as a dependency of [tap@15.2.3](https://github.com/tapjs/tapjs/tree/v15.2.3) and this is the version to install.

This is caused by a bug in Yarn Classic (v1), which is however unsupported since January 2020 (see [Yarn 1 GitHub repo](https://github.com/yarnpkg/yarn) and [Yarn Classic v1 documentation](https://classic.yarnpkg.com/en/docs/install)) and so there is no expectation that the bug will be fixed. The problem does not occur in Yarn Modern, or in npm.

## Change

In [yarn.yaml](https://github.com/cypress-io/request/blob/master/.github/workflows/yarn.yaml), change to use:

```shell
yarn install --ignore-engines
```

Note that this does not allow the workflow to succeed, because then `yarn test` fails, however it does provide more information about the status of the repository, if dependency installation is successful and tests can run.
