### PR TITLE
Chore: use npm creds context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ workflows:
       - test
       - release:
           context:
-            - test-runner:npm-release
+            - [test-runner:npm-release, org-npm-credentials]
           requires:
             - test
           filters:


### PR DESCRIPTION
uses new npm context to more easily adhere to token rotation