### PR TITLE
fix(deps): bump qs to ^6.15.2 (CVE-2026-8723)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "json-stringify-safe": "~5.0.1",
     "mime-types": "~2.1.19",
     "performance-now": "^2.1.0",
-    "qs": "~6.14.1",
+    "qs": "^6.15.2",
     "safe-buffer": "^5.1.2",
     "tough-cookie": "^5.0.0",
     "tunnel-agent": "^0.6.0"

--- a/tests/test-form-data.js
+++ b/tests/test-form-data.js
@@ -29,7 +29,7 @@ function runTest (t, options) {
       }
     }
 
-    t.ok(/multipart\/form-data; boundary=--------------------------\d+/
+    t.ok(/multipart\/form-data; boundary=--------------------------[0-9a-f]+/
       .test(req.headers['content-type']))
 
     // temp workaround

--- a/tests/test-form.js
+++ b/tests/test-form.js
@@ -20,7 +20,7 @@ tape('multipart form append', function (t) {
       return
     }
 
-    t.ok(/multipart\/form-data; boundary=--------------------------\d+/
+    t.ok(/multipart\/form-data; boundary=--------------------------[0-9a-f]+/
       .test(req.headers['content-type']))
 
     // temp workaround

--- a/yarn.lock
+++ b/yarn.lock
@@ -4914,10 +4914,17 @@ qjobs@^1.1.4:
   resolved "https://registry.yarnpkg.com/qjobs/-/qjobs-1.2.0.tgz#c45e9c61800bd087ef88d7e256423bdd49e5d071"
   integrity sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==
 
-qs@^6.12.3, qs@~6.14.0, qs@~6.14.1:
+qs@^6.12.3, qs@~6.14.0:
   version "6.14.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.1.tgz#a41d85b9d3902f31d27861790506294881871159"
   integrity sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==
+  dependencies:
+    side-channel "^1.1.0"
+
+qs@^6.15.2:
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
 


### PR DESCRIPTION
## Summary

Bumps the `qs` dependency range from `~6.14.1` to `^6.15.2` so it resolves to the patched 6.15.2 release.

The tilde range previously capped resolution at 6.14.x, which does not include the fix for [GHSA-q8mj-m7cp-5q26](https://github.com/ljharb/qs/security/advisories/GHSA-q8mj-m7cp-5q26) / [CVE-2026-8723](https://nvd.nist.gov/vuln/detail/CVE-2026-8723) (`qs.stringify` throws a `TypeError` when called with `arrayFormat: "comma"` and `encodeValuesOnly: true` on arrays containing `null`/`undefined`, enabling a remotely triggerable DoS).

After this change `yarn.lock` resolves `qs@^6.15.2` to `6.15.2`.

Closes #106

## Additional fix: form-data boundary regex in tests

While verifying CI, the `test-form.js` and `test-form-data.js` boundary assertions were failing:

```js
/multipart\/form-data; boundary=--------------------------\d+/.test(...)
```

`form-data@4.x` generates boundaries from `crypto.randomBytes`, producing **hex** strings (e.g. `--------------------------10a3756468ba6207f9c8a83e`). The `\d+` class only matches digits, so the assertion failed any time the random hex contained `a–f` (effectively almost always). The class is widened to `[0-9a-f]+`.

This is unrelated to the `qs` bump — the breakage was pre-existing and surfaces here only because CI happened to re-run. Bundling the one-line fix to keep CI green for the `qs` change.

## References

- [GHSA-q8mj-m7cp-5q26](https://github.com/ljharb/qs/security/advisories/GHSA-q8mj-m7cp-5q26)
- [CVE-2026-8723](https://nvd.nist.gov/vuln/detail/CVE-2026-8723)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only security patch with small test regex updates; no application logic changes in the request library itself.
> 
> **Overview**
> **Bumps `qs` from `~6.14.1` to `^6.15.2`** so installs resolve to **6.15.2**, addressing **CVE-2026-8723** (DoS via `qs.stringify` with certain `arrayFormat` / `encodeValuesOnly` options). The tilde range previously blocked picking up the patched release.
> 
> `yarn.lock` is updated accordingly. Multipart tests in `test-form-data.js` and `test-form.js` now expect **hex** multipart boundaries (`[0-9a-f]+` instead of `\d+`), matching behavior from the upgraded dependency chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7ed1bcfb96b29a684682c0b196449c766a670a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->